### PR TITLE
Fixes for bsc#1135879

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # saptune configuration editor for YaST
-This is a minimal YaST program for generating [saptune](https://github.com/HouzuoGuo/saptune) configuration and controlling its state.
+This is a minimal YaST program for generating [saptune](https://github.com/SUSE/saptune) configuration and controlling its state.
 
 # RPM package
 You may find a ready-made RPM spec file at https://build.opensuse.org/package/show/SUSE:SLE-12-SP2:GA/yast2-saptune

--- a/package/yast2-saptune.changes
+++ b/package/yast2-saptune.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon May 22 12:19:40 UTC 2019 - abriel@suse.com
+
+- Fixes for bsc#1135879
+  Fix to disable tuned daemon, if saptune is not configured.
+  Adjust some misleading messages and lables.
+  Adapt the new saptune solution behaviour.
+  Add new path to the fillup-template directory.
+
+-------------------------------------------------------------------
 Thu Jan 25 14:10:52 UTC 2018 - varkoly@suse.com
 
 - Fix typo. bsc#1077615

--- a/package/yast2-saptune.spec
+++ b/package/yast2-saptune.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-saptune
 #
-# Copyright (c) 2016 SUSE LINUX Products GmbH, Nuernberg, Germany.
+# Copyright (c) 2016-2019 SUSE LLC.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-saptune
-Version:        1.2
+Version:        1.3
 Release:        0
 License:        GPL-3.0
 Summary:        An alternative and minimal interface for configuring saptune

--- a/src/lib/saptuneui/main_dialog.rb
+++ b/src/lib/saptuneui/main_dialog.rb
@@ -47,8 +47,8 @@ module Saptune
                 VSpacing(1),
                 MinWidth(50, Frame(_('Status'), HSquash(HBox(
                     VBox(
-                        Left(Label(_('Daemon Status'))),
-                        Left(Label(_('Configuration Status'))),
+                        Left(Label(_('tuned Daemon Status: '))),
+                        Left(Label(_('Configuration Status: '))),
                     ),
                     VBox(
                         Left(Label(Id(:daemon_status), '')),
@@ -125,7 +125,7 @@ Would you like to install and use it now?')) && Package.DoInstall(['saptune'])
                                 nw, hana, success, out = SaptuneConfInst.auto_config
                                 if success
                                     if !hana && !nw
-                                        Popup.Message(_('Cannot find a compatible installed SAP software to tune for, only generic performance tuning is performed.'))
+                                        Popup.Message(_('Cannot find a compatible installed SAP software to tune for, so no performance tuning is performed.'))
                                     else
                                         prods = ''
                                         prods += "- SAP Netweaver\n" if nw
@@ -138,14 +138,14 @@ Would you like to install and use it now?')) && Package.DoInstall(['saptune'])
                                 end
                             when :daemon_toggle
                                 case SaptuneConfInst.state
-                                    when :ok
+                                    when :ok, :no_conf
                                         success, out = SaptuneConfInst.set_state(false)
                                         if success
                                             Popup.AnyMessage(_('Success'), _('saptune is now disabled.'))
                                         else
                                             Popup.ErrorDetails(_('Failed to disable saptune'), _('Error output: ') + out)
                                         end
-                                    when :stopped, :no_conf
+                                    when :stopped
                                         success, out = SaptuneConfInst.set_state(true)
                                         if success
                                             Popup.AnyMessage(_('Success'), _('saptune is now enabled.'))


### PR DESCRIPTION
Fix to disable tuned daemon, if saptune is not configured.
Adjust some misleading messages and lables.
Adapt the new saptune solution behaviour.
Add new path to the fillup-template directory.