### PR TITLE
add saptune v3 support

### DIFF
--- a/package/yast2-saptune.changes
+++ b/package/yast2-saptune.changes
@@ -1,12 +1,14 @@
 -------------------------------------------------------------------
-Thu Jul  1 09:12:44 UTC 2021 - abriel@suse.com
+Mon Jul  5 13:19:06 UTC 2021 - abriel@suse.com
 
 - version update from 1.3 to 1.4 to include the following fixes:
 
 - Fixes for jsc#SLE-6457
+
   Exchange the tuned daemon handling with the new saptune service
   handling for saptune version 3, but stay with the old behaviour
   for systems running saptune version 2.
+  Add information, if the service is enabled or disabled.
 
 -------------------------------------------------------------------
 Mon Jul  1 11:32:38 UTC 2019 - abriel@suse.com

--- a/package/yast2-saptune.changes
+++ b/package/yast2-saptune.changes
@@ -1,4 +1,14 @@
 -------------------------------------------------------------------
+Thu Jul  1 09:12:44 UTC 2021 - abriel@suse.com
+
+- version update from 1.3 to 1.4 to include the following fixes:
+
+- Fixes for jsc#SLE-6457
+  Exchange the tuned daemon handling with the new saptune service
+  handling for saptune version 3, but stay with the old behaviour
+  for systems running saptune version 2.
+
+-------------------------------------------------------------------
 Mon Jul  1 11:32:38 UTC 2019 - abriel@suse.com
 
 - version update from 1.2 to 1.3 to include the following fixes:

--- a/package/yast2-saptune.spec
+++ b/package/yast2-saptune.spec
@@ -1,7 +1,7 @@
 #
 # spec file for package yast2-saptune
 #
-# Copyright (c) 2016-2019 SUSE LLC.
+# Copyright (c) 2016-2021 SUSE LLC.
 #
 # All modifications and additions to the file contributed by third parties
 # remain the property of their copyright owners, unless otherwise agreed
@@ -16,7 +16,7 @@
 #
 
 Name:           yast2-saptune
-Version:        1.3
+Version:        1.4
 Release:        0
 License:        GPL-3.0
 Summary:        An alternative and minimal interface for configuring saptune

--- a/src/desktop/saptune.desktop
+++ b/src/desktop/saptune.desktop
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2016-2021 SUSE LLC.
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of version 3 of the GNU General Public License as published by the
@@ -27,7 +27,7 @@ X-SuSE-YaST-RootOnly=true
 X-SuSE-YaST-AutoInst=all
 X-SuSE-YaST-AutoInstClonable=true
 X-SuSE-YaST-AutoInstResource=saptune
-X-SuSE-YaST-Keywords=sap,saptune,tune,tuned,optimise,optimize,performance
+X-SuSE-YaST-Keywords=sap,saptune,tune,optimise,optimize,performance
 
 Icon=yast-sysconfig
 Exec=xdg-su -c "/sbin/yast2 saptune"

--- a/src/lib/saptune/saptune_conf.rb
+++ b/src/lib/saptune/saptune_conf.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # ------------------------------------------------------------------------------
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2016-2021 SUSE LLC.
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of version 3 of the GNU General Public License as published by the
@@ -201,7 +201,7 @@ module Saptune
         end
     end
 
-    # Manipulate sapconf and saptune daemons.
+    # Manipulate sapconf and saptune services.
     class SaptuneConf
         include Yast::I18n
         include Yast::Logger
@@ -236,32 +236,47 @@ module Saptune
 
         # Return status of saptune:
         # :ok - saptune is running and tuning has been done
-        # :stopped - saptune's daemon (tuned.service) is stopped
-        # :no_conf - saptune is not configured or tuned.service profile is incorrect
+        # :stopped - saptune's service (saptune.service) is stopped
+        # :not_tuned - saptune has no applied notes
+        # :no_conf - saptune is not configured
         def state
-            _, status = call_saptune_and_log('daemon', 'status')
+            if is_new_saptune_vers
+                _, status = call_saptune_and_log('service', 'status')
+            else
+                _, status = call_saptune_and_log('daemon', 'status')
+            end
             if status == 0
                 return :ok
             elsif status == 1
                 return :stopped
+            elsif status == 3
+                return :not_tuned
             else
                 return :no_conf
             end
         end
 
-        # Enable+start or disable+stop saptune and its daemon (tuned.service).
-        # It may take up to a minute to enable+start the daemon.
+        # Enable+start or disable+stop saptune and its service (saptune.service).
+        # It may take up to a minute to enable+start the serice.
         # Return boolean status and debug output (only in error case).
         # Boolean status is true only if the operation is carried out successfully.
         def set_state(enable)
             if enable
                 disable_sapconf
-                out, status = call_saptune_and_log('daemon', 'start')
+                if is_new_saptune_vers
+                    out, status = call_saptune_and_log('service', 'takeover')
+                else
+                    out, status = call_saptune_and_log('daemon', 'start')
+                end
                 if status != 0
                     return false, out
                 end
             else
-                out, status = call_saptune_and_log('daemon', 'stop')
+                if is_new_saptune_vers
+                    out, status = call_saptune_and_log('service', 'disablestop')
+                else
+                    out, status = call_saptune_and_log('daemon', 'stop')
+                end
                 if status != 0
                     return false, out
                 end
@@ -276,6 +291,15 @@ module Saptune
             has_nw = ['log', 'data', 'work', 'exe'].all?{|name| Dir.glob("/usr/sap/*/#{name}").any?}
             has_hana = Dir.glob('/usr/sap/*/HDB*/HDB').any?
             return [has_nw, has_hana]
+        end
+
+        # Look, if saptune version >= 3 is installed
+        def is_new_saptune_vers
+            path_workarea = '/var/lib/saptune/working/notes'
+            if !File.exists?(path_workarea)
+                return false
+            end
+            return true
         end
 
         # Return true only if sapconf is presently used, and its configuration has never deviated from default.
@@ -327,6 +351,8 @@ module Saptune
 
             if can_replace_sapconf
                 disable_sapconf
+                # revert settings first before add the new one.
+                out, status = call_saptune_and_log('revert', 'all')
                 log.info 'tuning system using saptune'
                 if has_nw && has_hana
                     path_solution = '/usr/share/saptune/solutions'
@@ -360,19 +386,30 @@ module Saptune
                         return has_nw, has_hana, false, out
                     end
                 end
-                out, status = call_saptune_and_log('daemon', 'start')
+                if is_new_saptune_vers
+                    out, status = call_saptune_and_log('service', 'takeover')
+                else
+                    out, status = call_saptune_and_log('daemon', 'start')
+                end
                 return has_nw, has_hana, status == 0, out
             end
 
             log.info 'tuning system using sapconf'
             if has_nw
-                out, status = call_sapconf_and_log('start')
+                out, status = call_sapconf_and_log('netweaver')
                 if status != 0
                     return has_nw, has_hana, false, out
                 end
             end
             if has_hana
                 out, status = call_sapconf_and_log('hana')
+                if status != 0
+                    return has_nw, has_hana, false, out
+                end
+            end
+            if !has_hana && !has_nw
+                # start sapconf with the last active profile
+                out, status = call_sapconf_and_log('start')
                 if status != 0
                     return has_nw, has_hana, false, out
                 end

--- a/src/lib/saptuneui/main_dialog.rb
+++ b/src/lib/saptuneui/main_dialog.rb
@@ -1,6 +1,6 @@
 # encoding: utf-8
 # ------------------------------------------------------------------------------
-# Copyright (c) 2016 SUSE LINUX GmbH, Nuernberg, Germany.
+# Copyright (c) 2016-2021 SUSE LLC.
 #
 # This program is free software; you can redistribute it and/or modify it under
 # the terms of version 3 of the GNU General Public License as published by the
@@ -47,18 +47,18 @@ module Saptune
                 VSpacing(1),
                 MinWidth(50, Frame(_('Status'), HSquash(HBox(
                     VBox(
-                        Left(Label(_('tuned Daemon Status: '))),
+                        Left(Label(_('saptune Service Status: '))),
                         Left(Label(_('Configuration Status: '))),
                     ),
                     VBox(
-                        Left(Label(Id(:daemon_status), '')),
+                        Left(Label(Id(:service_status), '')),
                         Left(Label(Id(:config_status), '')),
                     ),
                 )))),
                 VSpacing(1),
                 MinWidth(50, Frame(_('Action'), HSquash(RadioButtonGroup(Id(:action), VBox(
                     Left(RadioButton(Id(:genconf), '')),
-                    Left(RadioButton(Id(:daemon_toggle), '')),
+                    Left(RadioButton(Id(:service_toggle), '')),
                 ))))),
                 VSpacing(1),
                 Label(_('saptune comprehensively manages system optimisations for SAP solutions.')),
@@ -71,21 +71,21 @@ module Saptune
                 ),
             ))
             case SaptuneConfInst.state
-                when :ok
-                    UI.ChangeWidget(Id(:daemon_status), :Label, _('Running'))
+                when :ok, :not_tuned
+                    UI.ChangeWidget(Id(:service_status), :Label, _('Running'))
                     UI.ChangeWidget(Id(:config_status), :Label, _('Present'))
                     UI.ChangeWidget(Id(:genconf), :Label, _('Re-generate configuration'))
-                    UI.ChangeWidget(Id(:daemon_toggle), :Label, _('Disable and stop the daemon'))
+                    UI.ChangeWidget(Id(:service_toggle), :Label, _('Disable and stop the service'))
                 when :stopped
-                    UI.ChangeWidget(Id(:daemon_status), :Label, _('Not Running'))
+                    UI.ChangeWidget(Id(:service_status), :Label, _('Not Running'))
                     UI.ChangeWidget(Id(:config_status), :Label, _('Unknown'))
-                    UI.ChangeWidget(Id(:genconf), :Label, _('Re-generate configuration and enable the daemon'))
-                    UI.ChangeWidget(Id(:daemon_toggle), :Label, _('Enable and start the daemon'))
+                    UI.ChangeWidget(Id(:genconf), :Label, _('Re-generate configuration and enable the service'))
+                    UI.ChangeWidget(Id(:service_toggle), :Label, _('Enable and start the service'))
                 when :no_conf
-                    UI.ChangeWidget(Id(:daemon_status), :Label, _('Running'))
+                    UI.ChangeWidget(Id(:service_status), :Label, _('Unknown'))
                     UI.ChangeWidget(Id(:config_status), :Label, _('Absent'))
                     UI.ChangeWidget(Id(:genconf), :Label, _('Generate configuration automatically'))
-                    UI.ChangeWidget(Id(:daemon_toggle), :Label, _('Disable and stop the daemon'))
+                    UI.ChangeWidget(Id(:service_toggle), :Label, _('Disable and stop the service'))
             end
             UI.RecalcLayout
 
@@ -136,9 +136,9 @@ Would you like to install and use it now?')) && Package.DoInstall(['saptune'])
                                 else
                                     Popup.ErrorDetails(_('Failed to apply new configuration'), _('Error output: ') + out)
                                 end
-                            when :daemon_toggle
+                            when :service_toggle
                                 case SaptuneConfInst.state
-                                    when :ok, :no_conf
+                                    when :ok, :no_conf, :not_tuned
                                         success, out = SaptuneConfInst.set_state(false)
                                         if success
                                             Popup.AnyMessage(_('Success'), _('saptune is now disabled.'))

--- a/src/lib/saptuneui/main_dialog.rb
+++ b/src/lib/saptuneui/main_dialog.rb
@@ -72,20 +72,40 @@ module Saptune
             ))
             case SaptuneConfInst.state
                 when :ok, :not_tuned
-                    UI.ChangeWidget(Id(:service_status), :Label, _('Running'))
+                    if SaptuneConfInst.is_service_enabled
+                        UI.ChangeWidget(Id(:service_status), :Label, _('Enabled and Running'))
+                        UI.ChangeWidget(Id(:service_toggle), :Label, _('Disable and stop the service'))
+                    else
+                        UI.ChangeWidget(Id(:service_status), :Label, _('Disabled and Running'))
+                        UI.ChangeWidget(Id(:service_toggle), :Label, _('Stop the service'))
+                    end
                     UI.ChangeWidget(Id(:config_status), :Label, _('Present'))
                     UI.ChangeWidget(Id(:genconf), :Label, _('Re-generate configuration'))
-                    UI.ChangeWidget(Id(:service_toggle), :Label, _('Disable and stop the service'))
                 when :stopped
-                    UI.ChangeWidget(Id(:service_status), :Label, _('Not Running'))
+                    if SaptuneConfInst.is_service_enabled
+                        UI.ChangeWidget(Id(:service_status), :Label, _('Enabled, but Not Running'))
+                        UI.ChangeWidget(Id(:service_toggle), :Label, _('Start the service'))
+                    else
+                        UI.ChangeWidget(Id(:service_status), :Label, _('Disabled and Not Running'))
+                        UI.ChangeWidget(Id(:service_toggle), :Label, _('Enable and start the service'))
+                    end
                     UI.ChangeWidget(Id(:config_status), :Label, _('Unknown'))
-                    UI.ChangeWidget(Id(:genconf), :Label, _('Re-generate configuration and enable the service'))
-                    UI.ChangeWidget(Id(:service_toggle), :Label, _('Enable and start the service'))
+                    UI.ChangeWidget(Id(:genconf), :Label, _('Re-generate configuration and start the service'))
                 when :no_conf
+                    if SaptuneConfInst.is_service_enabled
+                        UI.ChangeWidget(Id(:service_status), :Label, _('Enabled and Running'))
+                        UI.ChangeWidget(Id(:service_toggle), :Label, _('Disable and stop the service'))
+                    else
+                        UI.ChangeWidget(Id(:service_status), :Label, _('Disabled and Running'))
+                        UI.ChangeWidget(Id(:service_toggle), :Label, _('Stop the service'))
+                    end
+                    UI.ChangeWidget(Id(:config_status), :Label, _('Absent'))
+                    UI.ChangeWidget(Id(:genconf), :Label, _('Generate configuration automatically'))
+                when :unknown
                     UI.ChangeWidget(Id(:service_status), :Label, _('Unknown'))
                     UI.ChangeWidget(Id(:config_status), :Label, _('Absent'))
                     UI.ChangeWidget(Id(:genconf), :Label, _('Generate configuration automatically'))
-                    UI.ChangeWidget(Id(:service_toggle), :Label, _('Disable and stop the service'))
+                    UI.ChangeWidget(Id(:service_toggle), :Label, _('Enable and start the service'))
             end
             UI.RecalcLayout
 
@@ -145,7 +165,7 @@ Would you like to install and use it now?')) && Package.DoInstall(['saptune'])
                                         else
                                             Popup.ErrorDetails(_('Failed to disable saptune'), _('Error output: ') + out)
                                         end
-                                    when :stopped
+                                    when :stopped, :unknown
                                         success, out = SaptuneConfInst.set_state(true)
                                         if success
                                             Popup.AnyMessage(_('Success'), _('saptune is now enabled.'))

--- a/test/saptune_test.rb
+++ b/test/saptune_test.rb
@@ -35,7 +35,7 @@ describe SaptuneConfInst do
     end
 
     it '.state' do
-        expect(SaptuneConfInst.state).to eq(:no_conf)
+        expect(SaptuneConfInst.state).to eq(:unknown)
     end
 
     it '.set_state' do


### PR DESCRIPTION
Exchange the tuned daemon handling with the new saptune service handling for saptune version 3, but stay with the old behaviour for systems running saptune version 2.
 Add a fix for the new solution behaviour starting with saptune version 2
Add information, if the service is enabled or disabled.
For a better support of v3 differ between :no_conf (ret=2 in v2) and an unknown error (ret<0 or ret>3)

